### PR TITLE
AD-15708: Script to set the autoAssociateIDPUser on all organizations in on-prem instance

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,12 @@ $ bluescape user delete --from-csv=./sample/user_delete.csv --new-owner-id=zANz6
 # Add custom link to the users in the CSV file user by email Id and CSV file
 $ bluescape customlink add --from-csv=./sample/customlink.csv --blocked-domains=./sample/blocked-domains.csv
 ```
+### Siloed User Provisioning
+```sh
+# Enable autoAssociateIdentityProviderUser for an organization and add an account to an organization
+# Both organizationId and accountId are optional. So we can execute both (valid Ids) or at least one argument is required.
+$ bluescape siloeduserprovision set --organizationId="ORGANIZATION_UID" --accountId="ACCOUNT_UID"
+```
 
 
 ## Uninstall

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@bluescape/cli",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@bluescape/cli",
-      "version": "1.0.5",
+      "version": "1.0.6",
       "license": "ISC",
       "dependencies": {
         "axios": "0.27.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bluescape/cli",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "description": "Bluescape command line tool",
   "private": true,
   "type": "commonjs",

--- a/src/commands/siloeduserprovision.ts
+++ b/src/commands/siloeduserprovision.ts
@@ -5,6 +5,5 @@ export const desc = 'set organization IDP and account';
 export const builder: CommandBuilder = (yargs) =>
   yargs.commandDir('siloeduserprovision');
 export const handler = (_argv: Arguments): void => {
-    console.log(_argv)
   console.log('siloed user provisioning');
 };

--- a/src/commands/siloeduserprovision.ts
+++ b/src/commands/siloeduserprovision.ts
@@ -1,0 +1,10 @@
+import type { Arguments, CommandBuilder } from 'yargs';
+
+export const command = 'siloeduserprovision <command>';
+export const desc = 'set organization IDP and account';
+export const builder: CommandBuilder = (yargs) =>
+  yargs.commandDir('siloeduserprovision');
+export const handler = (_argv: Arguments): void => {
+    console.log(_argv)
+  console.log('siloed user provisioning');
+};

--- a/src/commands/siloeduserprovision/set.ts
+++ b/src/commands/siloeduserprovision/set.ts
@@ -1,0 +1,166 @@
+import chalk from 'chalk';
+import ora from 'ora';
+import { organizationService } from '../../services';
+import { isId } from '../../utils/validators';
+import { Builder, Handler } from '../user/get.types';
+
+export const command = 'set';
+export const desc = 'Siloed user provisioning';
+
+export const builder: Builder = (yargs) =>
+  yargs.example([
+    [
+      '$0 siloeduserprovision set --organizationId="organizationId" --accountId="accountId"',
+    ],
+  ]);
+
+export const handler: Handler = async (argv) => {
+  const startTime = performance.now();
+
+  // Get the arguments
+  const { organizationId, accountId } = argv;
+
+  // organizationId validation
+  if (!organizationId) {
+    throw new Error('Please pass the organization id');
+  } else if (organizationId && !isId(organizationId)) {
+    throw new Error('Invalid organizationId. Value must be a valid Id');
+  }
+
+  // accountId validation
+  if (accountId && !isId(accountId)) {
+    throw new Error('Invalid accountId. Value must be a valid Id');
+  }
+
+  // Loading
+  const spinner = ora({
+    isSilent: argv.quiet as boolean,
+  });
+
+  const failedUserWithReasons = [];
+  let totalOrganizationsCount = 0;
+
+  try {
+    // Organization exist or not.
+    const organization = await organizationService.getOrganizationById(
+      organizationId as string,
+    );
+
+    if (organization.errors) {
+      spinner.fail(
+        chalk.red(
+          `Failed to get organization:  ${organizationId}\nReason: ${organization.errors[0].message}`,
+        ),
+      );
+      return;
+    }
+
+    const mapOrganizations = async (nextCursor = null) => {
+      // Get all the organizations
+      // limit 100
+      const {
+        data: {
+          organizations: { results, next, totalItems },
+        },
+      } = await organizationService.getAllOrganizations(
+        100,
+        nextCursor,
+        nextCursor === null,
+      );
+      // Assigned the total organizations
+      // totalItems prop get the first time only
+      totalOrganizationsCount = totalItems || totalOrganizationsCount;
+      nextCursor = next;
+
+      for await (const organization of results) {
+        try {
+          // Given organization autoAssociateIdentityProviderUser is false then update it to true
+          if (
+            !organization.autoAssociateIdentityProviderUser &&
+            organization.id === organizationId
+          ) {
+            await organizationService.updateOrganizationAutoAssociateIDPUser(
+              organization.id,
+              true,
+            );
+          } else {
+            //
+            await organizationService.updateOrganizationAutoAssociateIDPUser(
+              organization.id,
+              false,
+            );
+          }
+          spinner.succeed(
+            chalk.green(`Updated IDP for organization: ${organization?.id}`),
+          );
+          if (accountId) {
+            // account exists then update the accounts to the all the organizations in the instance.
+            const data = await organizationService.addOrganizationToAccount(
+              organization?.id,
+              accountId as string,
+            );
+            if (data.error) {
+              const message = data.error.response.data.message || data.error;
+              spinner.fail(
+                chalk.red(
+                  `Failed to update account for organization: ${organization?.id}. Reason: ${message}`,
+                ),
+              );
+            } else {
+              spinner.succeed(
+                chalk.blue(
+                  `Updated account for organization: ${organization?.id}`,
+                ),
+              );
+            }
+          }
+        } catch (e) {
+          spinner.fail(
+            chalk.red(
+              `Failed to Update IDP for organization: ${organization?.id}`,
+            ),
+          );
+          failedUserWithReasons.push({
+            organizationId: organization?.id,
+            message: e?.message,
+          });
+          continue;
+        }
+      }
+      // Check the pagination is end
+      if (nextCursor && nextCursor !== null) {
+        await mapOrganizations(nextCursor);
+      }
+    };
+    await mapOrganizations();
+  } catch (e) {
+    spinner.fail(chalk.red(e.message));
+  }
+
+  const failedListCount = failedUserWithReasons.length;
+
+  const endTime = performance.now();
+
+  console.log(`\n`);
+
+  spinner.info(
+    chalk.blue(
+      `Total organizations: ${totalOrganizationsCount}     Execution Time: ${(
+        endTime - startTime
+      ).toFixed(2)} ms\n`,
+    ),
+  );
+
+  if (failedListCount === 0) {
+    spinner.succeed(
+      chalk.green(
+        `All organizations are updated with their autoAssociateIdentityProviderUser field, Successful count - ${totalOrganizationsCount}\n`,
+      ),
+    );
+  } else {
+    spinner.succeed(
+      chalk.green(`Passed: ${totalOrganizationsCount - failedListCount}\n`),
+    );
+    spinner.fail(chalk.red(`Failed:  ${failedUserWithReasons.length}\n`));
+  }
+};

--- a/src/services/account.service.ts
+++ b/src/services/account.service.ts
@@ -1,0 +1,20 @@
+import { FetchRequestType, Service } from '../types';
+import { FetchService } from './fetch.service';
+
+export class AccountService extends FetchService {
+  constructor() {
+    super();
+  }
+
+  async getAccountById(accountId: string): Promise<any> {
+    const path = `/accounts/:accountId`;
+    const url = this.getUrlForService(Service.ISAM, path);
+    let data;
+    try {
+      data = await this.request(FetchRequestType.Get, url);
+      return data;
+    } catch (error) {
+      return { error };
+    }
+  }
+}

--- a/src/services/account.service.ts
+++ b/src/services/account.service.ts
@@ -7,11 +7,10 @@ export class AccountService extends FetchService {
   }
 
   async getAccountById(accountId: string): Promise<any> {
-    const path = `/accounts/:accountId`;
+    const path = `/accounts/${accountId}`;
     const url = this.getUrlForService(Service.ISAM, path);
-    let data;
     try {
-      data = await this.request(FetchRequestType.Get, url);
+      const data = await this.request(FetchRequestType.Get, url);
       return data;
     } catch (error) {
       return { error };

--- a/src/services/index.ts
+++ b/src/services/index.ts
@@ -4,6 +4,7 @@ import { EmailMigrationService } from './email-migrate.service';
 import { OrganizationService } from './organization.service';
 import { ProvisionLicenseService } from './provision-license.service';
 import { UserService } from './user.service';
+import { AccountService } from './account.service';
 
 const authService = new AuthService();
 const userService = new UserService();
@@ -11,6 +12,7 @@ const customLinkService = new CustomLinkService();
 const organizationService = new OrganizationService();
 const emailMigrationService = new EmailMigrationService();
 const provisionLicenseService = new ProvisionLicenseService();
+const accountService = new AccountService();
 
 export {
   authService,
@@ -19,4 +21,5 @@ export {
   organizationService,
   emailMigrationService,
   provisionLicenseService,
+  accountService,
 };

--- a/src/services/organization.service.ts
+++ b/src/services/organization.service.ts
@@ -18,7 +18,7 @@ export class OrganizationService extends FetchService {
     if (cursor) {
       query += `, cursor: "${cursor}"`;
     }
-    query += `){results{id name autoAssociateIdentityProviderUser} next`;
+    query += `){results{id name autoAssociateIdentityProviderUser accountId identityProvider { id }} next`;
     if (includeTotalCount) {
       query += ` totalItems`;
     }
@@ -36,6 +36,8 @@ export class OrganizationService extends FetchService {
       'canHaveGuests',
       'isGuestInviteApprovalRequired',
       'defaultOrganizationUserRole { id type }',
+      'identityProvider { id }',
+      'accountId'
     ];
     const query = `{organization(organizationId:"${orgnaizationId}"){${attributes.concat(
       '\n',
@@ -212,6 +214,25 @@ export class OrganizationService extends FetchService {
     };
     try {
       const data = await this.request(FetchRequestType.Patch, url, {
+        ...payload,
+      });
+      return data;
+    } catch (error) {
+      return { error };
+    }
+  }
+
+  async getOrganizationIdp(
+    identityProviderId: string,
+  ): Promise<any> {
+    const path = `/identityProviders/${identityProviderId}`;
+
+    const url = this.getUrlForService(Service.ISAM, path);
+    const payload = {
+      identityProviderId,
+    };
+    try {
+      const data = await this.request(FetchRequestType.Get, url, {
         ...payload,
       });
       return data;


### PR DESCRIPTION
[AD-15708](https://jira.common.bluescape.com/browse/AD-15708)
[AD-15709](https://jira.common.bluescape.com/browse/AD-15709)
We combined both scripts into one and executed them. Added both arguments organizationId/accountId as optional (at least one required) 
1. Check the given organization `autoAssociateIdentityProviderUser` field. If it is not true, then update the field as true. Mark all other organization's flags as `false`.
2. If account id is present in the argument, map all the organizations in the instance with that account.

<img width="780" alt="Screenshot 2023-05-02 at 8 29 39 PM" src="https://user-images.githubusercontent.com/41102370/235712228-c63c0ebc-7b50-4b50-bac2-901102d9a636.png">
<img width="933" alt="Screenshot 2023-05-02 at 8 30 09 PM" src="https://user-images.githubusercontent.com/41102370/235712254-0c39ac97-3f0b-44f9-b392-2cee852452bc.png">
<img width="896" alt="Screenshot 2023-05-02 at 8 30 31 PM" src="https://user-images.githubusercontent.com/41102370/235712286-950d3daf-6d72-402e-8562-0f5e6a8e2382.png">
<img width="1384" alt="Screenshot 2023-05-02 at 8 49 19 PM" src="https://user-images.githubusercontent.com/41102370/235712389-d0880ddf-c76b-4427-8d49-f2da555a955e.png">
<img width="1304" alt="Screenshot 2023-05-02 at 8 49 33 PM" src="https://user-images.githubusercontent.com/41102370/235712414-7942ebd6-a67f-4e88-a0dd-543275f00356.png">
